### PR TITLE
Correção na geração de PDF de NF-e para caracteres inválidos.

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -824,12 +824,16 @@ class Danfe extends Common
         $cdata = preg_replace('/\s\s+/', ' ', $cdata);
         $cdata = str_replace("> <", "><", $cdata);
 
+        if (strpos($cdata, '<') === false) {
+            return $cdata;
+        }
+
         $texto = strip_tags($cdata);
         $xmlClean = '<CDATA>' . $texto . '</CDATA>';
 
         //carrega o xml CDATA em um objeto DOM
         $dom = new Dom();
-        $dom->loadXML($xmlClean, LIBXML_NOBLANKS | LIBXML_NOEMPTYTAG);
+        $dom->loadXML($xmlClean, LIBXML_NOBLANKS | LIBXML_NOEMPTYTAG | LIBXML_NOERROR);
 
         //$xml = $dom->saveXML();
         //grupo CDATA infADprod


### PR DESCRIPTION
- Foi adicionada uma checagem para ignorar formatação ANFAVEA caso o texto contenha
o caracter "<" (inicio de nova tag).
- Foi adicionado também a opção de ignorar erros de php ao carregar o xml com o texto
a ser convertido, pois é muito dificil fazer a tratativa para caracteres inválidos, uma
vez que o campo é texto livre e pode conter qualquer tipo de informação.