### PR TITLE
Correção de sobreposição de descrição do item na última página

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2762,7 +2762,7 @@ class Danfe extends Common
         $this->pdf->line($x+$w1, $y, $x+$w1, $y+$hmax);
         //DESCRIÇÃO DO PRODUTO / SERVIÇO
         $x += $w1;
-        $w2 = round($w*0.25, 0);
+        $w2 = round($w*0.2835, 0);
         $texto = 'DESCRIÇÃO DO PRODUTO / SERVIÇO';
         $aFont = ['font'=>$this->fontePadrao, 'size'=>6, 'style'=>''];
         $this->pdf->textBox($x, $y, $w2, $h, $texto, $aFont, 'C', 'C', 0, '', false);
@@ -2800,7 +2800,7 @@ class Danfe extends Common
         $this->pdf->line($x+$w6, $y, $x+$w6, $y+$hmax);
         //QUANT
         $x += $w6;
-        $w7 = round($w*0.08, 0);
+        $w7 = round($w*0.0465, 0);
         $texto = 'QUANT';
         $aFont = ['font'=>$this->fontePadrao, 'size'=>6, 'style'=>''];
         $this->pdf->textBox($x, $y, $w7, $h, $texto, $aFont, 'C', 'C', 0, '', false);


### PR DESCRIPTION
Em alguns casos, na última página, as descrições dos últimos itens ultrapassavam o limite vertical da linha que delimita o documento. Foi ajustada a largura dos campos "DESCRIÇÃO DO PRODUTO / SERVIÇO" e "QUANT" de forma que uma maior descrição possa caber adequadamente na renderização do espaço disponível para cada linha.

Links:

+ https://arquivei.atlassian.net/browse/BONDERS-1128

Signed-off-by: Victor Hugo Diniz Brito dos Santos <victor.diniz@arquivei.com.br>