### PR TITLE
Ajuste de metodo inexistente na geracao de pdf.

### DIFF
--- a/src/CTe/DacteOSV3.php
+++ b/src/CTe/DacteOSV3.php
@@ -1809,6 +1809,18 @@ class DacteOSV3 extends Common
     } //fim da função zModalRod
 
     /**
+     * zModalAereo
+     * Monta o campo com os dados do remetente na DACTE. ( retrato  e paisagem  )
+     *
+     * @param  number $x Posição horizontal canto esquerdo
+     * @param  number $y Posição vertical canto superior
+     * @return number Posição vertical final
+     */
+    protected function zModalAereo($x=0, $y=0){
+        //TODO Workaround until to be developed
+    }
+
+    /**
      * zModalAquaviario
      * Monta o campo com os dados do remetente na DACTE. ( retrato  e paisagem  )
      *


### PR DESCRIPTION
O metodo zModalAereo nao existia na sped-da o que causava um erro quando caia no caso de uso em que ele eh necessario.

Adicionamos o metodo, mas com corpo inexistente (deve ser implementado futuramente).