### PR TITLE
Adiciona tratamento caso o campo infCpl ou infAdProd contenha a tag HTML de quebra de linha

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -734,6 +734,8 @@ class Danfe extends Common
         $cdata = str_replace(']]>', '</CDATA>', $cdata);
         $cdata = preg_replace('/\s\s+/', ' ', $cdata);
         $cdata = str_replace("> <", "><", $cdata);
+        $cdata = str_replace("<br />", ' ', $cdata);
+
         $len = strlen($cdata);
         $startPos = strpos($cdata, '<');
         if ($startPos === false) {


### PR DESCRIPTION
Identificamos que existia um problema no campo de 'Dados Adicionais' da Danfe.
Esse problema era ocasionado por tags de quebra de linha (<br \>) no meio do campo infCpl ou infAdProd, que fazia com que a função `anfaveaDANFE` tratasse o texto de forma errada, removendo parte da descrição desse campo.
A solução para esse problema foi remover as tags de quebra de linha.

link: 
https://arquivei.atlassian.net/browse/BONDERS-1886