### PR TITLE
Ajusta código para não quebrar ao realizar os testes de integração co…

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -515,9 +515,9 @@ class Dacte extends Common
         if (!empty($this->logomarca)) {
             $logoInfo = getimagesize($this->logomarca);
             //largura da imagem em mm
-            $logoWmm = ($logoInfo[0] / 72) * 25.4;
+            $logoWmm = $logoInfo[0] > 0 ? ($logoInfo[0] / 72) * 25.4 : 212;
             //altura da imagem em mm
-            $logoHmm = ($logoInfo[1] / 72) * 25.4;
+            $logoHmm = $logoInfo[1] > 0 ? ($logoInfo[1] / 72) * 25.4 : 129;
             if ($this->logoAlign == 'L') {
                 $nImgW = round($w / 3, 0);
                 $nImgH = round($logoHmm * ($nImgW / $logoWmm), 0);

--- a/src/CTe/DacteOS.php
+++ b/src/CTe/DacteOS.php
@@ -159,7 +159,7 @@ class DacteOS extends Common
             if (!is_numeric($vTrib)) {
                 $vTrib = 0;
             }
-            $textoAdic = number_format($vTrib, 2, ",", ".");
+            $textoAdic = !empty($vTrib) ? number_format($vTrib, 2, ",", ".") : '';
             $this->textoAdic = "o valor aproximado de tributos incidentes sobre o preço deste serviço é de R$"
                 .$textoAdic;
             $this->toma = $this->dom->getElementsByTagName("toma")->item(0);
@@ -447,9 +447,9 @@ class DacteOS extends Common
         if (!empty($this->logomarca)) {
             $logoInfo = getimagesize($this->logomarca);
             //largura da imagem em mm
-            $logoWmm = ($logoInfo[0] / 72) * 25.4;
+            $logoWmm = $logoInfo[0] > 0 ? ($logoInfo[0] / 72) * 25.4 : 212;
             //altura da imagem em mm
-            $logoHmm = ($logoInfo[1] / 72) * 25.4;
+            $logoHmm = $logoInfo[1] > 0 ? ($logoInfo[1] / 72) * 25.4 : 129;
             if ($this->logoAlign == 'L') {
                 $nImgW = round($w / 3, 0);
                 $nImgH = round($logoHmm * ($nImgW / $logoWmm), 0);
@@ -1177,7 +1177,8 @@ class DacteOS extends Common
         $texto = 'VALOR TOTAL DO SERVIÇO';
         $aFont = $this->formatPadrao;
         $this->pdf->textBox($x, $y, $w * 0.14, $h, $texto, $aFont, 'T', 'C', 0, '');
-        $texto = number_format($this->getTagValue($this->vPrest, "vTPrest"), 2, ",", ".");
+        $texto = !empty($this->getTagValue($this->vPrest, "vTPrest")) ?
+            number_format($this->getTagValue($this->vPrest, "vTPrest"), 2, ",", ".") : '';
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 9,
@@ -1189,7 +1190,8 @@ class DacteOS extends Common
         $texto = 'VALOR A RECEBER';
         $aFont = $this->formatPadrao;
         $this->pdf->textBox($x, $y, $w * 0.14, $h, $texto, $aFont, 'T', 'C', 0, '');
-        $texto = number_format($this->getTagValue($this->vPrest, "vRec"), 2, ",", ".");
+        $texto = !empty($this->getTagValue($this->vPrest, "vRec")) ?
+            number_format($this->getTagValue($this->vPrest, "vRec"), 2, ",", ".") : '';
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 9,
@@ -1200,12 +1202,13 @@ class DacteOS extends Common
 
         foreach ($this->Comp as $k => $d) {
             $nome = $this->Comp->item($k)->getElementsByTagName('xNome')->item(0)->nodeValue;
-            $valor = number_format(
-                $this->Comp->item($k)->getElementsByTagName('vComp')->item(0)->nodeValue,
-                2,
-                ",",
-                "."
-            );
+            $valor = !empty($this->Comp->item($k)->getElementsByTagName('vComp')->item(0)->nodeValue) ?
+                number_format(
+                    $this->Comp->item($k)->getElementsByTagName('vComp')->item(0)->nodeValue,
+                    2,
+                    ",",
+                    "."
+            ) : '';
             if ($auxX > $w * 0.60) {
                 $yIniDados = $yIniDados + 4;
                 $auxX = $oldX;
@@ -1355,7 +1358,8 @@ class DacteOS extends Common
         $cUF = $this->ide->getElementsByTagName('cUF')->item(0)->nodeValue;
         $CNPJ = "00000000000000" . $this->emit->getElementsByTagName('CNPJ')->item(0)->nodeValue;
         $CNPJ = substr($CNPJ, -14);
-        $vCT = number_format($this->getTagValue($this->vPrest, "vRec"), 2, "", "") * 100;
+        $vCT = !empty($this->getTagValue($this->vPrest, "vRec")) ?
+            number_format($this->getTagValue($this->vPrest, "vRec"), 2, "", "") * 100 : '';
         $ICMS_CST = $this->getTagValue($this->ICMS, "CST");
         switch ($ICMS_CST) {
             case '00':
@@ -1448,7 +1452,8 @@ class DacteOS extends Common
 
         $x = $oldX;
         $y = $y + 4;
-        $texto = number_format($this->getTagValue($this->infQ->item(0), "qCarga"), 3, ",", ".");
+        $texto = !empty($this->getTagValue($this->infQ->item(0), "qCarga")) ?
+            number_format($this->getTagValue($this->infQ->item(0), "qCarga"), 3, ",", ".") : '';
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($x, $y, $w * 0.26, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x += $w * 0.26;
@@ -1519,7 +1524,8 @@ class DacteOS extends Common
             'size' => 8,
             'style' => '');
         $this->pdf->textBox($auxX, $yIniDados, $w, $h, $texto, $aFont, 'T', 'L', 0, '');
-        $texto = number_format($this->getTagValue($this->vPrest, "vTPrest"), 2, ",", ".");
+        $texto = !empty($this->getTagValue($this->vPrest, "vTPrest")) ?
+            number_format($this->getTagValue($this->vPrest, "vTPrest"), 2, ",", ".") : '';
         $aFont = array(
             'font' => $this->fontePadrao,
             'size' => 8,

--- a/src/MDFe/Damdfe.php
+++ b/src/MDFe/Damdfe.php
@@ -266,9 +266,9 @@ class Damdfe extends Common
         if (is_file($this->logomarca)) {
             $logoInfo = getimagesize($this->logomarca);
             //largura da imagem em mm
-            $logoWmm = ($logoInfo[0] / 72) * 25.4;
+            $logoWmm = $logoInfo[0] > 0 ? ($logoInfo[0] / 72) * 25.4 : 212;
             //altura da imagem em mm
-            $logoHmm = ($logoInfo[1] / 72) * 25.4;
+            $logoHmm = $logoInfo[1] > 0 ? ($logoInfo[1] / 72) * 25.4 : 129;
             if ($this->logoAlign == 'L') {
                 $nImgW = round($w / 3, 0);
                 $nImgH = round($logoHmm * ($nImgW / $logoWmm), 0);
@@ -410,9 +410,9 @@ class Damdfe extends Common
         if (is_file($this->logomarca)) {
             $logoInfo = getimagesize($this->logomarca);
             //largura da imagem em mm
-            $logoWmm = ($logoInfo[0] / 72) * 25.4;
+            $logoWmm = $logoInfo[0] > 0 ? ($logoInfo[0] / 72) * 25.4 : 212;
             //altura da imagem em mm
-            $logoHmm = ($logoInfo[1] / 72) * 25.4;
+            $logoHmm = $logoInfo[1] > 0 ? ($logoInfo[1] / 72) * 25.4 : 129;
             if ($this->logoAlign == 'L') {
                 // ajusta a dimensão do logo
                 $nImgW = round((round($maxW * 0.50, 0)) / 3, 0);

--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -969,9 +969,9 @@ class Danfe extends Common
                 $type == 'jpg';
             }
             //largura da imagem em mm
-            $logoWmm = ($logoInfo[0]/72)*25.4;
+            $logoWmm = $logoInfo[0] > 0 ? ($logoInfo[0]/72)*25.4 : 212;
             //altura da imagem em mm
-            $logoHmm = ($logoInfo[1]/72)*25.4;
+            $logoHmm = $logoInfo[1] > 0 ? ($logoInfo[1]/72)*25.4 : 129;
             if ($this->logoAlign=='L') {
                 $nImgW = round($w/3, 0);
                 $nImgH = round($logoHmm * ($nImgW/$logoWmm), 0);
@@ -1196,9 +1196,10 @@ class Danfe extends Common
                     $texto = ! empty($this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue)
                     ? $this->nfeProc->getElementsByTagName("nProt")->item(0)->nodeValue
                     : '';
-                    $tsHora = $this->toTimestamp(
-                        $this->nfeProc->getElementsByTagName("dhRecbto")->item(0)->nodeValue
-                    );
+                    $tsHora = !empty($this->nfeProc->getElementsByTagName("dhRecbto")->item(0)->nodeValue) ?
+                        $this->toTimestamp(
+                            $this->nfeProc->getElementsByTagName("dhRecbto")->item(0)->nodeValue
+                    ) : '';
                     if ($texto != '') {
                         $texto .= "  -  " . date('d/m/Y H:i:s', $tsHora);
                     }
@@ -1605,7 +1606,7 @@ class Danfe extends Common
             $dhSaiEnt = ! empty($this->ide->getElementsByTagName("dhSaiEnt")->item(0)->nodeValue)
             ? $this->ide->getElementsByTagName("dhSaiEnt")->item(0)->nodeValue
             : '';
-            $tsDhSaiEnt = $this->toTimestamp($dhSaiEnt);
+            $tsDhSaiEnt = !empty($dhSaiEnt) ? $this->toTimestamp($dhSaiEnt) : '';
             if ($tsDhSaiEnt != '') {
                 $hSaiEnt = date('H:i:s', $tsDhSaiEnt);
             }
@@ -2941,11 +2942,13 @@ class Danfe extends Common
                     $alinhamento = 'R';
                 }
                 // QTDADE
-                $texto = number_format($prod->getElementsByTagName("qCom")->item(0)->nodeValue, 4, ",", ".");
+                $texto = !empty($prod->getElementsByTagName("qCom")->item(0)->nodeValue) ?
+                    number_format($prod->getElementsByTagName("qCom")->item(0)->nodeValue, 4, ",", ".") : '';
                 $this->pdf->textBox($x, $y, $w7, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 $x += $w7;
                 // Valor Unitário
-                $texto = number_format($prod->getElementsByTagName("vUnCom")->item(0)->nodeValue, 4, ",", ".");
+                $texto = !empty($prod->getElementsByTagName("vUnCom")->item(0)->nodeValue) ?
+                    number_format($prod->getElementsByTagName("vUnCom")->item(0)->nodeValue, 4, ",", ".") : '';
                 $this->pdf->textBox($x, $y, $w8, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 $x += $w8;
                 // Valor do Produto
@@ -2956,7 +2959,8 @@ class Danfe extends Common
                 $this->pdf->textBox($x, $y, $w9, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 $x += $w9;
                 //Valor do Desconto
-                $texto = number_format($prod->getElementsByTagName("vDesc")->item(0)->nodeValue, 2, ",", ".");
+                $texto = !empty($prod->getElementsByTagName("vDesc")->item(0)->nodeValue) ?
+                    number_format($prod->getElementsByTagName("vDesc")->item(0)->nodeValue, 2, ",", ".") : '';
                 $this->pdf->textBox($x, $y, $w10, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 //Valor da Base de calculo
                 $x += $w10;
@@ -3288,7 +3292,7 @@ class Danfe extends Common
         if (isset($this->ISSQNtot)) {
             $texto = ! empty($this->ISSQNtot->getElementsByTagName("vServ")->item(0)->nodeValue) ?
                     $this->ISSQNtot->getElementsByTagName("vServ")->item(0)->nodeValue : '';
-            $texto = number_format($texto, 2, ",", ".");
+            $texto = !empty($texto) ? number_format($texto, 2, ",", ".") : '';
         } else {
             $texto = '';
         }
@@ -3529,7 +3533,8 @@ class Danfe extends Common
         }
         $texto .= $this->ymdTodmy($dEmi) ." ";
         $texto .= "VALOR TOTAL: R$ ";
-        $texto .= number_format($this->ICMSTot->getElementsByTagName("vNF")->item(0)->nodeValue, 2, ",", ".") . " ";
+        $texto .= !empty($this->ICMSTot->getElementsByTagName("vNF")->item(0)->nodeValue) ?
+            number_format($this->ICMSTot->getElementsByTagName("vNF")->item(0)->nodeValue, 2, ",", ".") . " " : '';
         $texto .= "DESTINATÁRIO: ";
         $texto .= $destinatario;
         if ($this->orientacao == 'P') {


### PR DESCRIPTION
…m a da-api

Ao instalar a lib na da-api e commitar, os testes de integração falham devido a alguns problemas com number_format, toTimestamp e divisão por zero no tamanho do logo

Foram realizados alguns ajustes nas classes Danfe.php, Dacte.php, DacteOS.php e Damdfe.php para que seja possível a utilização sem que haja falhas

Link: https://arquivei.atlassian.net/jira/software/c/projects/ENGAJA/boards/147\?modal\=detail\&selectedIssue\=ENGAJA-86