### PR TITLE
Ajustes no código de Danfe.php para aparecer valor 0,00 de desconto, …

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -2960,7 +2960,7 @@ class Danfe extends Common
                 $x += $w9;
                 //Valor do Desconto
                 $texto = !empty($prod->getElementsByTagName("vDesc")->item(0)->nodeValue) ?
-                    number_format($prod->getElementsByTagName("vDesc")->item(0)->nodeValue, 2, ",", ".") : '';
+                    number_format($prod->getElementsByTagName("vDesc")->item(0)->nodeValue, 2, ",", ".") : '0,00';
                 $this->pdf->textBox($x, $y, $w10, $h, $texto, $aFont, 'T', $alinhamento, 0, '');
                 //Valor da Base de calculo
                 $x += $w10;


### PR DESCRIPTION
…caso não haja desconto

Após os ajustes das releases v0.2.3.7 e v0.2.3.8 para permitir que a da-api após atualizar a versão do PHP para 8.1 consiga utilizar a sped-da, em Danfe.php o desconto deveria aparecer 0,00 caso não haja e estava surgindo como um campo vazio.

Foi ajustado o código de Danfe.php e adicionado uma verificação para que quando não haja valor de desconto seja impresso 0,00 no documento auxiliar.

Link: https://arquivei.atlassian.net/jira/software/c/projects/ENGAJA/boards/147\?modal\=detail\&selectedIssue\=ENGAJA-86