### PR TITLE
Grupo infGTVE DACTe e DACTeOS

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -1964,7 +1964,7 @@ class Dacte extends Common
         $auxX = $oldX;
         $yIniDados += 4;
         foreach ($this->Comp as $k => $d) {
-            $nome = $this->Comp->item($k)->getElementsByTagName('xNome')->item(0)->nodeValue;
+            $nome = $this->Comp->item($k)->getElementsByTagName('tpComp')->item(0)->nodeValue;
             $valor = number_format(
                 $this->Comp->item($k)->getElementsByTagName('vComp')->item(0)->nodeValue,
                 2,

--- a/src/CTe/DacteOSV3.php
+++ b/src/CTe/DacteOSV3.php
@@ -1281,7 +1281,7 @@ class DacteOSV3 extends Common
         $yIniDados += 4;
 
         foreach ($this->Comp as $k => $d) {
-            $nome = $this->Comp->item($k)->getElementsByTagName('xNome')->item(0)->nodeValue;
+            $nome = $this->Comp->item($k)->getElementsByTagName('tpComp')->item(0)->nodeValue;
             $valor = number_format(
                 (float) $this->Comp->item($k)->getElementsByTagName('vComp')->item(0)->nodeValue,
                 2,

--- a/src/CTe/DacteV3.php
+++ b/src/CTe/DacteV3.php
@@ -1951,7 +1951,7 @@ class DacteV3 extends Common
         $auxX = $oldX;
         $yIniDados += 4;
         foreach ($this->Comp as $k => $d) {
-            $nome = $this->Comp->item($k)->getElementsByTagName('xNome')->item(0)->nodeValue;
+            $nome = $this->Comp->item($k)->getElementsByTagName('tpComp')->item(0)->nodeValue;
             $valor = number_format(
                 $this->Comp->item($k)->getElementsByTagName('vComp')->item(0)->nodeValue,
                 2,


### PR DESCRIPTION
Problema
A geração de PDF da CTe e CTeOS possui um mapeamento de tag errada: infGTVe->Comp->xNome

Solução
Corrigir para a tag correta infGTVe->Comp->tpComp

Link:
https://arquivei.atlassian.net/browse/ENGAJA-1080