### PR TITLE
Impressão das chaves de CTe vinculada em documentos de transporte anterior

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -145,6 +145,7 @@ class Dacte extends DaCommon
             $this->infNF = $this->dom->getElementsByTagName("infNF");
             $this->infNFe = $this->dom->getElementsByTagName("infNFe");
             $this->infOutros = $this->dom->getElementsByTagName("infOutros");
+            $this->idDocAntEle = $this->dom->getElementsByTagName("idDocAntEle");
             $this->infCTeMultimodal = $this->dom->getElementsByTagName("infCTeMultimodal");
             $this->compl = $this->dom->getElementsByTagName("compl");
             $this->ICMS = $this->dom->getElementsByTagName("ICMS")->item(0);
@@ -2636,7 +2637,7 @@ class Dacte extends DaCommon
         }
         foreach ($this->idDocAntEle as $k => $d) {
             $tp = 'CT-e';
-            $chaveCTe = $this->idDocAntEle->item($k)->getElementsByTagName('chave')->item(0)->nodeValue;
+            $chaveCTe = $this->idDocAntEle->item($k)->getElementsByTagName('chCTe')->item(0)->nodeValue;
             $numCTe = substr($chaveCTe, 25, 9);
             $serieCTe = substr($chaveCTe, 22, 3);
             $doc = $serieCTe . '/' . $numCTe;


### PR DESCRIPTION
As chaves de CTe vinculadas em documentos de transporte anterior não estavam sendo impressas na DACTe.

Como essa correção foi feita no projeto original ([003a6190945b7af4c38e49ca4f03472f8b2e6d47](https://github.com/nfephp-org/sped-da/commit/003a6190945b7af4c38e49ca4f03472f8b2e6d47)), podemos utilizar este commit para a correção.