### PR TITLE
Adiciona tags para geração de DACTeOS

### DIFF
--- a/src/CTe/DacteOS.php
+++ b/src/CTe/DacteOS.php
@@ -1317,19 +1317,28 @@ class DacteOS extends Common
         $x += $w * 0.26;
 
         $texto = !empty($this->ICMS->getElementsByTagName("vBC")->item(0)->nodeValue) ?
-            number_format($this->getTagValue($this->ICMS, "vBC"), 2, ",", ".") : '';
+            number_format($this->getTagValue($this->ICMS, "vBC"), 2, ",", ".") : (
+            !empty($this->ICMS->getElementsByTagName("vBCOutraUF")->item(0)->nodeValue) ?
+                number_format($this->getTagValue($this->ICMS, "vBCOutraUF"), 2, ",", ".") : ''
+            );
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($x, $y, $w * $wCol02, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x += $w * $wCol02;
 
         $texto = !empty($this->ICMS->getElementsByTagName("pICMS")->item(0)->nodeValue) ?
-            number_format($this->getTagValue($this->ICMS, "pICMS"), 2, ",", ".") : '';
+            number_format($this->getTagValue($this->ICMS, "pICMS"), 2, ",", ".") : (
+            !empty($this->ICMS->getElementsByTagName("pICMSOutraUF")->item(0)->nodeValue) ?
+                number_format($this->getTagValue($this->ICMS, "pICMSOutraUF"), 2, ",", ".") : ''
+            );
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($x, $y, $w * $wCol02, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x += $w * $wCol02;
 
         $texto = !empty($this->ICMS->getElementsByTagName("vICMS")->item(0)->nodeValue) ?
-            number_format($this->getTagValue($this->ICMS, "vICMS"), 2, ",", ".") : '';
+            number_format($this->getTagValue($this->ICMS, "vICMS"), 2, ",", ".") : (
+            !empty($this->ICMS->getElementsByTagName("vICMSOutraUF")->item(0)->nodeValue) ?
+                number_format($this->getTagValue($this->ICMS, "vICMSOutraUF"), 2, ",", ".") : ''
+            );
         $aFont = $this->formatNegrito;
         $this->pdf->textBox($x, $y, $w * $wCol02, $h, $texto, $aFont, 'T', 'L', 0, '');
         $x += $w * $wCol02;


### PR DESCRIPTION
As tags `<vBCOutraUF>`, `<pICMSOutraUF>` e `<vICMSOutraUF>`, não estão sendo renderizadas no documento auxiliar de CTeOs, porém, as mesmas, segundo o Anexo II do Manual de Orientação do Contribuinte (Manual de Especificações Técnicas do DACTE, versão 3 e 4), têm o mesmo uso que no documento auxiliar de CTe.

Para a correção, são adicionados os usos das tags.

[MOC_CTe_Anexo II_DACTE_v4.00.pdf](https://github.com/user-attachments/files/19759065/MOC_CTe_Anexo.II_DACTE_v4.00.pdf)
[MOC_CTe_Anexo II_DACTE_v3.00a.pdf](https://github.com/user-attachments/files/19759070/MOC_CTe_Anexo.II_DACTE_v3.00a.pdf)
