### PR TITLE
Adiciona função para aplicar fator multiplicador dependendo da medida utilizada em CTe

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -28,6 +28,7 @@ class Dacte extends Common
     const CODIGOUNIDADEMEDIDA_UNIDADE = '03';
 
     const TIPOMEDIDA_PESOBRUTO = 'PESO BRUTO';
+    const TIPOMEDIDA_TONELADA = 'TONELADA';
     const TIPOMEDIDA_PESOBASECALCULO = 'PESO BASE DE CÁLCULO';
     const TIPOMEDIDA_PESOAFERIDO = 'PESO AFERIDO';
 
@@ -1677,7 +1678,7 @@ class Dacte extends Common
      */
     private function getValidGrossWeight(string $valorPesoBaseCalculo, string $valorPesoAferido): string
     {
-        $valorPesoBruto = $this->getTagValueByTagReference($this->infQ, 'tpMed', self::TIPOMEDIDA_PESOBRUTO, 'qCarga');
+        $valorPesoBruto = $this->calculateWeight();
 
         if (empty($valorPesoBruto) && empty($valorPesoBaseCalculo) && empty($valorPesoAferido)) {
             foreach ($this->infQ as $infQ) {
@@ -1690,6 +1691,31 @@ class Dacte extends Common
         }
 
         return $valorPesoBruto;
+    }
+
+    /**
+     * Calcula o valor em Kg do tipo de medida trabalhado, aplicando o multiplicador correto
+     * Exemplo:
+     * Se a medida é tonelada, o multiplicador é 1000
+     * @return float|int|null
+     */
+    private function calculateWeight()
+    {
+        $measuresAndMultipliers = [
+            self::TIPOMEDIDA_PESOBRUTO => 1,
+            self::TIPOMEDIDA_TONELADA => 1000
+        ];
+
+        foreach (array_keys($measuresAndMultipliers) as $measure) {
+            $weight = $this->getTagValueByTagReference($this->infQ, 'tpMed', $measure, 'qCarga');
+
+            if (!empty($weight)) {
+                $multiplier = $measuresAndMultipliers[$measure];
+                return $weight * $multiplier;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -1678,7 +1678,7 @@ class Dacte extends Common
      */
     private function getValidGrossWeight(string $valorPesoBaseCalculo, string $valorPesoAferido): string
     {
-        $valorPesoBruto = $this->calculateWeight();
+        $valorPesoBruto = $this->weightByTypeOfMeasure();
 
         if (empty($valorPesoBruto) && empty($valorPesoBaseCalculo) && empty($valorPesoAferido)) {
             foreach ($this->infQ as $infQ) {
@@ -1694,24 +1694,21 @@ class Dacte extends Common
     }
 
     /**
-     * Calcula o valor em Kg do tipo de medida trabalhado, aplicando o multiplicador correto
-     * Exemplo:
-     * Se a medida é tonelada, o multiplicador é 1000
+     * Obtem o valor do peso de acordo com o tipo de medida do documento
      * @return float|int|null
      */
-    private function calculateWeight()
+    private function weightByTypeOfMeasure()
     {
-        $measuresAndMultipliers = [
-            self::TIPOMEDIDA_PESOBRUTO => 1,
-            self::TIPOMEDIDA_TONELADA => 1000
+        $measures = [
+            self::TIPOMEDIDA_PESOBRUTO,
+            self::TIPOMEDIDA_TONELADA
         ];
 
-        foreach (array_keys($measuresAndMultipliers) as $measure) {
+        foreach ($measures as $measure) {
             $weight = $this->getTagValueByTagReference($this->infQ, 'tpMed', $measure, 'qCarga');
 
             if (!empty($weight)) {
-                $multiplier = $measuresAndMultipliers[$measure];
-                return $weight * $multiplier;
+                return $weight;
             }
         }
 


### PR DESCRIPTION
Em algumas CTes o campo de peso está vindo com descrição para toneladas, fazendo o código ignorar o campo e deixando o campo em branco ao gerar o pdf.

Essa atualização faz com que `tonelada` seja uma opção válida e aplica o fator multiplicador para que seja transformada em kg.


![image-20250520-204404](https://github.com/user-attachments/assets/25848b70-e4ae-4925-9557-956087651aaa)
