### PR TITLE
Ajusta o retorno da função

### DIFF
--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -1695,7 +1695,7 @@ class Dacte extends Common
 
     /**
      * Obtem o valor do peso de acordo com o tipo de medida do documento
-     * @return float|int|null
+     * @return float|string
      */
     private function weightByTypeOfMeasure()
     {

--- a/src/CTe/Dacte.php
+++ b/src/CTe/Dacte.php
@@ -1712,7 +1712,7 @@ class Dacte extends Common
             }
         }
 
-        return null;
+        return "";
     }
 
     /**


### PR DESCRIPTION
Ajusta o retorno da função previamente mergeada, pois a função que chama a `weightByTypeOfMeasure` precisa retornar `string` e pode utilizar o valor retornado por  `weightByTypeOfMeasure`.