### PR TITLE
Fix: Corrige problema na tag infCpl

### DIFF
--- a/src/NFe/Danfe.php
+++ b/src/NFe/Danfe.php
@@ -520,7 +520,7 @@ class Danfe extends Common
                 $this->textoAdic .= ". \r\n";
             }
             $this->textoAdic .= ! empty($this->getTagValue($this->infAdic, "infCpl"))
-            ? 'Inf. Contribuinte: ' . $this->anfaveaDANFE($this->getTagValue($this->infAdic, "infCpl"))
+            ? 'Inf. Contribuinte: ' . $this->getTagValue($this->infAdic, "infCpl")
             : '';
             $infPedido = $this->geraInformacoesDaTagCompra();
             if ($infPedido != "") {


### PR DESCRIPTION
Corrige problema onde era ignorado o conteúdo que estava entre os sinais "<" e ">" nas informações complementares da DANFe.

Exemplo:
```
<infAdic>
  <infCpl>Essas são informações complementares &lt; Isso seria ignorado &gt;</infCpl>
</infAdic>
```